### PR TITLE
Update hybrid_system_subtypes.py

### DIFF
--- a/hysynth/utils/hybrid_system/hybrid_system_subtypes.py
+++ b/hysynth/utils/hybrid_system/hybrid_system_subtypes.py
@@ -1,4 +1,4 @@
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from collections.abc import Iterable
 from copy import deepcopy
 import scipy.spatial as spt


### PR DESCRIPTION
Since Python 3.10 this is needed.