### PR TITLE
Update single_inference.py

### DIFF
--- a/hysynth/pwl/initial_inference/single_inference.py
+++ b/hysynth/pwl/initial_inference/single_inference.py
@@ -16,7 +16,7 @@ from hysynth.pwl.initial_inference import lib as init_lib
 
 def infer_hybrid_system_polyhedral_pwl(pwl_points_list, delta_ha, delta_fh,
                                        epsilon_meanshift=False, hybrid_system_name=None,
-                                       pwl_slopes=None, only_consider_first_piece=True):
+                                       pwl_slopes=None, only_consider_first_piece=False):
     """ This function is the initial hybrid system inference function """
 
     # some safety and integrity checks since this is the outer interface function


### PR DESCRIPTION
This change seems to be needed to avoid results with only a single location. I do not remember the purpose and why this was set to `True`.